### PR TITLE
Branch max score validation

### DIFF
--- a/src/main/java/tutorlink/command/AddComponentCommand.java
+++ b/src/main/java/tutorlink/command/AddComponentCommand.java
@@ -129,14 +129,11 @@ public class AddComponentCommand extends Command {
             if (maxScore < 0.0) {
                 throw new IllegalValueException(Commons.ERROR_INVALID_MAX_SCORE);
             }
-<<<<<<< HEAD
 
             if (maxScore > MAX_SCORE) {
                 throw new IllegalValueException(Commons.ERROR_INVALID_MAX_SCORE);
             }
-
-=======
->>>>>>> master
+            
             return maxScore;
         } catch (NumberFormatException e) {
             throw new IllegalValueException(Commons.ERROR_INVALID_MAX_SCORE);

--- a/src/main/java/tutorlink/command/AddComponentCommand.java
+++ b/src/main/java/tutorlink/command/AddComponentCommand.java
@@ -15,6 +15,8 @@ public class AddComponentCommand extends Command {
     public static final String[] ARGUMENT_PREFIXES = {"c/", "w/", "m/"};
     public static final String COMMAND_WORD = "add_component";
 
+    private static final double MAX_SCORE = 10000.0;
+
     @Override
     public CommandResult execute(AppState appState, HashMap<String, String> hashmap) throws TutorLinkException {
         String componentName = hashmap.get(ARGUMENT_PREFIXES[0]);
@@ -55,6 +57,10 @@ public class AddComponentCommand extends Command {
             double maxScore = Double.parseDouble(maxScoreNumber);
 
             if (maxScore < 0.0) {
+                throw new IllegalValueException(Commons.ERROR_INVALID_MAX_SCORE);
+            }
+
+            if (maxScore > MAX_SCORE) {
                 throw new IllegalValueException(Commons.ERROR_INVALID_MAX_SCORE);
             }
 

--- a/src/main/java/tutorlink/commons/Commons.java
+++ b/src/main/java/tutorlink/commons/Commons.java
@@ -37,7 +37,7 @@ public class Commons {
             "in list!";
     public static final String ERROR_INVALID_WEIGHTAGE = "Error! Weightage must be integer that is between 0 and 100!";
     public static final String ERROR_INVALID_MAX_SCORE =
-            "Error! Max Score must be double that is more than or equal to 0!";
+            "Error! Max Score must be double that is between 0 and 10000!";
     //@@author RCPilot1604
     public static final String ERROR_INVALID_TOTAL_WEIGHTING = "Error! Total weighting must add up to 100%%.\n" +
             "Current weighting (after addition): %s%%";

--- a/src/test/java/tutorlink/command/AddComponentCommandTest.java
+++ b/src/test/java/tutorlink/command/AddComponentCommandTest.java
@@ -228,5 +228,13 @@ public class AddComponentCommandTest {
         command.execute(appState, arguments);
         assertEquals(student.getPercentageScore(), 50);
     }
+
+    @Test
+    void execute_maxScoreLargerThanMax_exception() {
+        arguments.put("c/", "Quiz 1");
+        arguments.put("w/", "100");
+        arguments.put("m/", "20000");
+        assertThrows(IllegalValueException.class, () -> command.execute(appState, arguments));
+    }
 }
 //@@author


### PR DESCRIPTION
Set a upper limit for max score to prevent (or at least dissuade) attempts at trying to get score to overflow (and display Infinity) and then labelling that as a bug.Functionality